### PR TITLE
Add Bazel support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ local.properties
 .cache-main
 .scala_dependencies
 .worksheet
+
+bazel
+bazel-*

--- a/hw2/BUILD
+++ b/hw2/BUILD
@@ -1,0 +1,5 @@
+java_binary(
+  name = "hw2",
+  srcs = glob(["src/**/*.java"]),
+  main_class = "Java",
+)


### PR DESCRIPTION
To install bazel: https://docs.bazel.build/versions/master/install.html

This pull request adds Bazel build support. To run `hw2`, run the following command at the root of the project:

```
$ bazel run //hw2:hw2 -- execute $PWD/hw2/javatest.txt
```

